### PR TITLE
Sphinx conf.py update

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -49,7 +49,7 @@ If you are proposing a feature:
 
 * Explain in detail how it would work.
 * Keep the scope as narrow as possible, to make it easier to implement.
-* Respect the [Python Code of Conduct](https://www.python.org/psf/codeofconduct/)
+* Respect the `Python Code of Conduct <https://www.python.org/psf/codeofconduct/>`_
 * Remember that this is a volunteer-driven project, and that contributions
   are welcome :)
 
@@ -89,5 +89,5 @@ Pull Request Guidelines
 
 Before you submit a pull request, check that it meets these guidelines:
 
-1. Adhere to [PEP8](https://www.python.org/dev/peps/pep-0008/)
+1. Adhere to `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_
 2. The pull request should work for Python 2.7, and 3.5.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ needs_sphinx = '1.3'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
 
 import scopus
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,17 +5,33 @@ scopus: A Python API for accessing Scopus data
 
 
 =======
-Modules
+Classes
 =======
 
-.. toctree::
-   :maxdepth: 1
+Currently, scopus provides the following classes to interact with the Scopus API (see https://dev.elsevier.com/api_docs.html):
 
-   reference/scopus_api
-   reference/scopus_author
-   reference/scopus_search
-   reference/scopus_affiliation
-   reference/scopus_reports
+.. currentmodule:: scopus.scopus_api
+.. autosummary::
+   ScopusAbstract
+
+.. currentmodule:: scopus.scopus_author
+.. autosummary::
+   ScopusAuthor
+
+.. currentmodule:: scopus.scopus_search
+.. autosummary::
+   ScopusSearch
+
+.. currentmodule:: scopus.scopus_affiliation
+.. autosummary::
+   ScopusAffiliation
+
+
+There is one class to provide reports:
+
+.. currentmodule:: scopus.scopus_reports
+.. autosummary::
+   report
 
 
 =====


### PR DESCRIPTION
The reason why the module documentation wasn't being shown in the references section was that the path to include extensions was not included.  I outcommented the respective lines in Sphinx' `conf.py`.

I furthermore implemented Sphinx' autosummary to get a quick overview (plus link) for the Scopus classes.