### PR TITLE
~Fixed references retrival in ScopusAbstract.__init__

### DIFF
--- a/scopus/scopus_api.py
+++ b/scopus/scopus_api.py
@@ -257,7 +257,7 @@ class ScopusAbstract(object):
         except:
             self._citationLang = None
         try:
-            self._references = tail.find('bibrecord/tail/bibliography', ns)
+            self._references = items.find('bibrecord/tail/bibliography', ns)
         except:
             self._references = None
 


### PR DESCRIPTION
Looks like there was a typo in constructor, that preveted getting reference list