### PR TITLE
Parse authkeywords from abstracts

### DIFF
--- a/scopus/scopus_api.py
+++ b/scopus/scopus_api.py
@@ -174,6 +174,13 @@ class ScopusAbstract(object):
         """
         return self._description
 
+    @property
+    def authkeywords(self):
+        """Return the keywords of the abstract.
+        Note: This may be empty.
+        """
+        return self._authkeywords
+
     def __init__(self, EID, view='META_ABS', refresh=False):
         """Class to represent the results from a Scopus abstract.
 
@@ -254,6 +261,13 @@ class ScopusAbstract(object):
         if cite_link:
             cite_link = cite_link.get('href')
         self.cite_link = cite_link
+
+        # Parse authkeywords
+        author_keywords = xml.find('authkeywords', ns)
+        try:
+            self._authkeywords = [a.text for a in author_keywords]
+        except:
+            self._authkeywords = None
 
         # Parse subject-areas
         subjectAreas = xml.find('subject-areas', ns)

--- a/scopus/tests/test_ScopusAbstract.py
+++ b/scopus/tests/test_ScopusAbstract.py
@@ -172,3 +172,14 @@ def test_volume():
 
 def test_website():
     assert_equal(ab.website, 'http://pubs.acs.org/page/accacs/about.html')
+
+
+def test_authkeywords():
+    ab2 = scopus.ScopusAbstract("2-s2.0-0000212165", view="FULL", refresh=True)
+    
+    authkeywords = ab2.authkeywords
+    assert_true(len(authkeywords) == 3)
+
+    assert_equal(authkeywords[0], 'Fuzzy clustering')
+    assert_equal(authkeywords[1], 'Fuzzy modelling')
+    assert_equal(authkeywords[2], 'Unsupervised learning')


### PR DESCRIPTION
I've seen that even if the Authkeywords are present in the dowloaded XMLs they are not parsed by class `ScopusAbstract` which is a pitty as they could be really intesting for some applications like creating a information retrieval system over downloaded abstracts