### PR TITLE
Cope with journal-history being unpopulated

### DIFF
--- a/scopus/author_retrieval.py
+++ b/scopus/author_retrieval.py
@@ -109,7 +109,8 @@ class AuthorRetrieval(Retrieval):
         """
         hist = []
         jour = namedtuple('Journal', 'sourcetitle abbreviation type issn')
-        pub_hist = self._json['author-profile']['journal-history'].get('journal', [])
+        jour_hist = self._json['author-profile'].get('journal-history', {})
+        pub_hist = jour_hist.get('journal', [])
         if not isinstance(pub_hist, list):
             pub_hist = [pub_hist]
         for pub in pub_hist:


### PR DESCRIPTION
Found another one...
To reproduce:
```
In [305]: AuthorRetrieval(8712982800).journal_history                                                                                                                                         
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-305-09a44d61a974> in <module>
----> 1 AuthorRetrieval(8712982800).journal_history

~/git/scopus-api/scopus/author_retrieval.py in journal_history(self)
    114         hist = []
    115         jour = namedtuple('Journal', 'sourcetitle abbreviation type issn')
--> 116         pub_hist = self._json['author-profile']['journal-history'].get('journal', [])
    117         if not isinstance(pub_hist, list):
    118             pub_hist = [pub_hist]

KeyError: 'journal-history'
```