### PR TITLE
Add REF view to references method

### DIFF
--- a/scopus/abstract_retrieval.py
+++ b/scopus/abstract_retrieval.py
@@ -367,49 +367,78 @@ class AbstractRetrieval(Retrieval):
     def references(self):
         """List of namedtuples representing references listed in the abstract,
         in the form (position, id, doi, title, authors, sourcetitle,
-        publicationyear, volume, issue, first, last, text, fulltext).
+        publicationyear, volume, issue, first, last, text, fulltext, scopuseid,
+        citedbycount).
         `position` is the number at which the reference appears in the
         document, `id` is the Scopus ID of the referenced abstract (EID
         without the "2-s2.0-"), `authors` is a list of the names of the
-        authors in the format "Surname, Initials", `first` and `last` refer
-        to the page range, `text` is Scopus-provided information on the
-        publication and `fulltext` is the text the authors used for
-        the reference.
-        Note: Requires the FULL view of the article.  Might be empty even if
-        refcount is positive.
+        authors in the format "Surname, Initials" if view is set to FULL, 
+        a list of namedtuples in the form (givenname, initials, surname,
+        indexedname, seq, affiliationid, affiliationhref, auid, authorurl)
+        if view is set to REF, `first` and `last` refer to the page range, 
+        `text` is Scopus-provided information on the publication and `fulltext`
+        is the text the authors used for the reference.
+        `text` and `fulltext` fields are always None if view is set to REF.
+        `scopuseid` nad `citedbycount` fields are always None if view is
+        set to FULL.
+        Note: Requires either the FULL view or REF view of the article. 
+        Might be empty even if refcount is positive.
         """
         out = []
         fields = 'position id doi title authors sourcetitle publicationyear '\
-                 'volume issue first last text fulltext'
+                 'volume issue first last text fulltext scopuseid citedbycount'
         ref = namedtuple('Reference', fields)
         path = ['item', 'bibrecord', 'tail', 'bibliography', 'reference']
-        items = listify(chained_get(self._json, path, []))
+        items = listify(chained_get(self._json, path, 
+                    self._json.get('references', {}).get('reference', [])))
         for item in items:
-            info = item['ref-info']
-            volisspag = info.get('ref-volisspag', {})
+            info = item.get('ref-info', item)
+            volisspag = info.get('ref-volisspag', info.get('volisspag') or {})
+            authors = []
             try:
                 auth = listify(info['ref-authors']['author'])
                 authors = [', '.join([d['ce:surname'], d['ce:initials']])
                            for d in auth]
             except KeyError:  # No authors given
-                authors = None
-            ids = listify(info['refd-itemidlist']['itemid'])
+                auth_fields = 'givenname initials surname indexedname seq affiliationid '\
+                              'affiliationhref auid authorurl'
+                auth = namedtuple('Author', auth_fields)
+                for author in info.get('author-list', {}).get('author', []):
+                    new_auth = auth(givenname=author.get('ce:given-name'),
+                                    initials=author.get('ce:initials'),
+                                    surname=author.get('ce:surname'),
+                                    indexedname=author.get('ce:indexed-name'),
+                                    seq=author.get('@seq'),
+                                    affiliationid=(author.get('affiliation') or {}).get('@id'),
+                                    affiliationhref=(author.get('affiliation') or {}).get('@href'),
+                                    auid=author.get('@auid'),
+                                    authorurl=author.get('author-url'))
+                    authors.append(new_auth)
+                                
+            ids = []
+            scopus_id = None
             try:
+                ids = listify(info['refd-itemidlist']['itemid'])
                 doi = [d['$'] for d in ids if d['@idtype'] == 'DOI'][0]
-            except IndexError:
-                doi = None
+                scopus_id = [d['$'] for d in ids if d['@idtype'] == 'SGR'][0]
+            except (KeyError, IndexError):
+                doi = info.get('ce:doi')
+                scopus_id = info.get('scopus-id')
+
             new = ref(position=item.get('@id'),
-                      id=[d['$'] for d in ids if d['@idtype'] == 'SGR'][0],
+                      id=scopus_id,
                       doi=doi, authors=authors,
-                      title=info.get('ref-title', {}).get('ref-titletext'),
-                      sourcetitle=info.get('ref-sourcetitle'),
+                      title=info.get('ref-title', {}).get('ref-titletext', info.get('title')),
+                      sourcetitle=info.get('ref-sourcetitle', info.get('sourcetitle')),
                       publicationyear=info.get('ref-publicationyear', {}).get('@first'),
                       volume=volisspag.get('voliss', {}).get('@volume'),
                       issue=volisspag.get('voliss', {}).get('@issue'),
                       first=volisspag.get('pagerange', {}).get('@first'),
                       last=volisspag.get('pagerange', {}).get('@last'),
                       text=info.get('ref-text'),
-                      fulltext=item.get('ref-fulltext'))
+                      fulltext=item.get('ref-fulltext'),
+                      scopuseid=info.get('scopus-eid'),
+                      citedbycount=info.get('citedby-count'))
             out.append(new)
         return out or None
 
@@ -519,7 +548,7 @@ class AbstractRetrieval(Retrieval):
         view : str (optional, default=META_ABS)
             The view of the file that should be downloaded.  Will not take
             effect for already cached files. Allowed values: META, META_ABS,
-            FULL, where FULL includes all information of META_ABS view and
+            REF, FULL, where FULL includes all information of META_ABS view and
             META_ABS includes all information of the META view .  See
             https://dev.elsevier.com/guides/AbstractRetrievalViews.htm
             for details.
@@ -544,7 +573,7 @@ class AbstractRetrieval(Retrieval):
             warn(text, UserWarning)
             identifier = EID
         identifier = str(identifier)
-        allowed_views = ('META', 'META_ABS', 'FULL')
+        allowed_views = ('META', 'META_ABS', 'REF', 'FULL')
         if view not in allowed_views:
             raise ValueError('view parameter must be one of ' +
                              ', '.join(allowed_views))

--- a/scopus/abstract_retrieval.py
+++ b/scopus/abstract_retrieval.py
@@ -387,8 +387,7 @@ class AbstractRetrieval(Retrieval):
         out = []
         fields = 'position id doi title authors sourcetitle publicationyear '\
                  'volume issue first last text fulltext citedbycount '\
-                 'authors_auid authors_url authors_affiliationurl '\
-                 'authors_affiliationid '
+                 'authors_auid authors_affiliationid '
         ref = namedtuple('Reference', fields)
         path = ['item', 'bibrecord', 'tail', 'bibliography', 'reference']
         items = listify(chained_get(self._json, path, 
@@ -399,8 +398,6 @@ class AbstractRetrieval(Retrieval):
             authors = []
             authors_seq = []
             authors_auid = []
-            authors_url = []
-            authors_aff_url = []
             authors_aff_id = []
             try:
                 auth = listify(item['ref-info']['ref-authors']['author'])
@@ -411,8 +408,6 @@ class AbstractRetrieval(Retrieval):
                 authors = [', '.join(filter(None, [d.get('ce:surname'), 
                             d.get('ce:given-name')])) for d in auth]
                 authors_auid = [d.get('@auid') for d in auth]
-                authors_url = [d.get('author-url') for d in auth]
-                authors_aff_url = [(d.get('affiliation') or {}).get('@href') for d in auth]
                 authors_aff_id = [(d.get('affiliation') or {}).get('@id') for d in auth]
                                 
             ids = []
@@ -443,8 +438,6 @@ class AbstractRetrieval(Retrieval):
                       fulltext=item.get('ref-fulltext'),
                       citedbycount=info.get('citedby-count'),
                       authors_auid=authors_auid,
-                      authors_url=authors_url,
-                      authors_affiliationurl=authors_aff_url,
                       authors_affiliationid=authors_aff_id)
             out.append(new)
         return out or None

--- a/scopus/abstract_retrieval.py
+++ b/scopus/abstract_retrieval.py
@@ -416,13 +416,16 @@ class AbstractRetrieval(Retrieval):
                     authors.append(new_auth)
                                 
             ids = []
-            scopus_id = None
             try:
                 ids = listify(info['refd-itemidlist']['itemid'])
                 doi = [d['$'] for d in ids if d['@idtype'] == 'DOI'][0]
-                scopus_id = [d['$'] for d in ids if d['@idtype'] == 'SGR'][0]
-            except (KeyError, IndexError):
+            except IndexError:
                 doi = info.get('ce:doi')
+
+            scopus_id = None
+            try:
+                scopus_id = [d['$'] for d in ids if d['@idtype'] == 'SGR'][0]
+            except KeyError:
                 scopus_id = info.get('scopus-id')
 
             new = ref(position=item.get('@id'),

--- a/scopus/tests/test_AbstractRetrieval.py
+++ b/scopus/tests/test_AbstractRetrieval.py
@@ -296,7 +296,9 @@ def test_refcount():
 
 def test_references():
     fields = 'position id doi title authors sourcetitle publicationyear '\
-             'volume issue first last text fulltext scopuseid citedbycount'
+             'volume issue first last text fulltext citedbycount '\
+             'authors_auid authors_url authors_affiliationurl '\
+             'authors_affiliationid '
     ref = namedtuple('Reference', fields)
     fulltext1 = 'Implementing Reproducible Research; Stodden, V.; Leisch, '\
                 'F.; Peng, R. D., Eds., Chapman and Hall/CRC: London, 2014.'
@@ -304,8 +306,9 @@ def test_references():
         authors=['Stodden, V.', 'Leisch, F.', 'Peng, R.D.'], fulltext=fulltext1,
         sourcetitle='Implementing Reproducible Research',
         publicationyear='2014', volume=None, issue=None, first=None,
-        last=None, text='Eds. Chapman and Hall/CRC: London.', scopuseid=None,
-        citedbycount=None)
+        last=None, text='Eds. Chapman and Hall/CRC: London.', citedbycount=None, 
+        authors_auid=[], authors_url=[], authors_affiliationurl=[],
+        authors_affiliationid=[])
     assert_equal(ab1.references[-1], expected1)
     assert_equal(ab2.references, None)
     fulltext4 = 'Chib, S., 1995, Marginal likelihood from the Gibbs output, '\
@@ -314,8 +317,9 @@ def test_references():
         title='Marginal likelihood from the Gibbs output', authors=['Chib, S.'],
         sourcetitle='Journal of the American Statistical Association',
         publicationyear='1995', volume='90', issue=None, first='1313',
-        last='1321', text=None, fulltext=fulltext4, scopuseid=None,
-        citedbycount=None)
+        last='1321', text=None, fulltext=fulltext4, citedbycount=None,
+        authors_auid=[], authors_url=[], authors_affiliationurl=[],
+        authors_affiliationid=[])
     assert_equal(ab4.references[0], expected4)
 
 

--- a/scopus/tests/test_AbstractRetrieval.py
+++ b/scopus/tests/test_AbstractRetrieval.py
@@ -300,8 +300,7 @@ def test_refcount():
 def test_references():
     fields = 'position id doi title authors sourcetitle publicationyear '\
              'volume issue first last text fulltext citedbycount '\
-             'authors_auid authors_url authors_affiliationurl '\
-             'authors_affiliationid '
+             'authors_auid authors_affiliationid '
     ref = namedtuple('Reference', fields)
     fulltext1 = 'Implementing Reproducible Research; Stodden, V.; Leisch, '\
                 'F.; Peng, R. D., Eds., Chapman and Hall/CRC: London, 2014.'
@@ -310,8 +309,7 @@ def test_references():
         sourcetitle='Implementing Reproducible Research',
         publicationyear='2014', volume=None, issue=None, first=None,
         last=None, text='Eds. Chapman and Hall/CRC: London.', citedbycount=None, 
-        authors_auid=[], authors_url=[], authors_affiliationurl=[],
-        authors_affiliationid=[])
+        authors_auid=[], authors_affiliationid=[])
     assert_equal(ab1.references[-1], expected1)
     assert_equal(ab2.references, None)
     fulltext4 = 'Chib, S., 1995, Marginal likelihood from the Gibbs output, '\
@@ -321,8 +319,7 @@ def test_references():
         sourcetitle='Journal of the American Statistical Association',
         publicationyear='1995', volume='90', issue=None, first='1313',
         last='1321', text=None, fulltext=fulltext4, citedbycount=None,
-        authors_auid=[], authors_url=[], authors_affiliationurl=[],
-        authors_affiliationid=[])
+        authors_auid=[], authors_affiliationid=[])
     assert_equal(ab4.references[0], expected4)
     expected8 =  ref(position='1', id='77950347409', 
         doi='10.1145/1721654.1721672',
@@ -336,30 +333,6 @@ def test_references():
         authors_auid=['35800975300', '35571093800', '57198081560', '7202236336',
             '7401788602', '25926395200', '56326032000', '7401930147', 
             '26534952300', '7007009125', '15064891400'], 
-        authors_url=[
-            'https://api.elsevier.com/content/author/author_id/35800975300',
-            'https://api.elsevier.com/content/author/author_id/35571093800',
-            'https://api.elsevier.com/content/author/author_id/57198081560',
-            'https://api.elsevier.com/content/author/author_id/7202236336',
-            'https://api.elsevier.com/content/author/author_id/7401788602',
-            'https://api.elsevier.com/content/author/author_id/25926395200',
-            'https://api.elsevier.com/content/author/author_id/56326032000',
-            'https://api.elsevier.com/content/author/author_id/7401930147',
-            'https://api.elsevier.com/content/author/author_id/26534952300',
-            'https://api.elsevier.com/content/author/author_id/7007009125',
-            'https://api.elsevier.com/content/author/author_id/15064891400'], 
-        authors_affiliationurl=[
-            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
-            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
-            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
-            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
-            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
-            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
-            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
-            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
-            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
-            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
-            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038'],
         authors_affiliationid=['60025038', '60025038', '60025038', '60025038', 
             '60025038', '60025038', '60025038', '60025038', '60025038', 
             '60025038', '60025038'])

--- a/scopus/tests/test_AbstractRetrieval.py
+++ b/scopus/tests/test_AbstractRetrieval.py
@@ -296,7 +296,7 @@ def test_refcount():
 
 def test_references():
     fields = 'position id doi title authors sourcetitle publicationyear '\
-             'volume issue first last text fulltext'
+             'volume issue first last text fulltext scopuseid citedbycount'
     ref = namedtuple('Reference', fields)
     fulltext1 = 'Implementing Reproducible Research; Stodden, V.; Leisch, '\
                 'F.; Peng, R. D., Eds., Chapman and Hall/CRC: London, 2014.'
@@ -304,7 +304,8 @@ def test_references():
         authors=['Stodden, V.', 'Leisch, F.', 'Peng, R.D.'], fulltext=fulltext1,
         sourcetitle='Implementing Reproducible Research',
         publicationyear='2014', volume=None, issue=None, first=None,
-        last=None, text='Eds. Chapman and Hall/CRC: London.',)
+        last=None, text='Eds. Chapman and Hall/CRC: London.', scopuseid=None,
+        citedbycount=None)
     assert_equal(ab1.references[-1], expected1)
     assert_equal(ab2.references, None)
     fulltext4 = 'Chib, S., 1995, Marginal likelihood from the Gibbs output, '\
@@ -313,7 +314,8 @@ def test_references():
         title='Marginal likelihood from the Gibbs output', authors=['Chib, S.'],
         sourcetitle='Journal of the American Statistical Association',
         publicationyear='1995', volume='90', issue=None, first='1313',
-        last='1321', text=None, fulltext=fulltext4)
+        last='1321', text=None, fulltext=fulltext4, scopuseid=None,
+        citedbycount=None)
     assert_equal(ab4.references[0], expected4)
 
 

--- a/scopus/tests/test_AbstractRetrieval.py
+++ b/scopus/tests/test_AbstractRetrieval.py
@@ -21,6 +21,9 @@ ab5 = scopus.AbstractRetrieval("2-s2.0-84919546381", view="FULL", refresh=True)
 ab6 = scopus.AbstractRetrieval("2-s2.0-85053478849", view="FULL", refresh=True)
 # Contributor group
 ab7 = scopus.AbstractRetrieval("2-s2.0-85050253030", view="FULL", refresh=True)
+# REF view
+ab8 = scopus.AbstractRetrieval("2-s2.0-84951753303", view="REF", refresh=True)
+
 
 
 def test_abstract():
@@ -321,6 +324,46 @@ def test_references():
         authors_auid=[], authors_url=[], authors_affiliationurl=[],
         authors_affiliationid=[])
     assert_equal(ab4.references[0], expected4)
+    expected8 =  ref(position='1', id='77950347409', 
+        doi='10.1145/1721654.1721672',
+        title='A view of cloud computing', authors=['Armbrust, Michael', 
+            'Fox, Armando', 'Griffith, Rean', 'Joseph, Anthony D.', 
+            'Katz, Randy', 'Konwinski, Andy', 'Lee, Gunho', 'Patterson, David', 
+            'Rabkin, Ariel', 'Stoica, Ion', 'Zaharia, Matei'],
+        sourcetitle='Communications of the ACM',
+        publicationyear=None, volume='53', issue='4', first='50',
+        last='58', text=None, fulltext=None, citedbycount='4972',
+        authors_auid=['35800975300', '35571093800', '57198081560', '7202236336',
+            '7401788602', '25926395200', '56326032000', '7401930147', 
+            '26534952300', '7007009125', '15064891400'], 
+        authors_url=[
+            'https://api.elsevier.com/content/author/author_id/35800975300',
+            'https://api.elsevier.com/content/author/author_id/35571093800',
+            'https://api.elsevier.com/content/author/author_id/57198081560',
+            'https://api.elsevier.com/content/author/author_id/7202236336',
+            'https://api.elsevier.com/content/author/author_id/7401788602',
+            'https://api.elsevier.com/content/author/author_id/25926395200',
+            'https://api.elsevier.com/content/author/author_id/56326032000',
+            'https://api.elsevier.com/content/author/author_id/7401930147',
+            'https://api.elsevier.com/content/author/author_id/26534952300',
+            'https://api.elsevier.com/content/author/author_id/7007009125',
+            'https://api.elsevier.com/content/author/author_id/15064891400'], 
+        authors_affiliationurl=[
+            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
+            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
+            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
+            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
+            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
+            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
+            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
+            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
+            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
+            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038',
+            'https://api.elsevier.com/content/affiliation/affiliation_id/60025038'],
+        authors_affiliationid=['60025038', '60025038', '60025038', '60025038', 
+            '60025038', '60025038', '60025038', '60025038', '60025038', 
+            '60025038', '60025038'])
+    assert_equal(ab8.references[0], expected8)
 
 
 def test_scopus_link():


### PR DESCRIPTION
I added the REF view to the references method in AbstractRetrieval. REF view introduces more authors info, so I introduced a namedtuples for the authors.
REF also includes the Scopus EID and the citedbycount fields, which I added to the existing Reference namedtuples.
I updated the references test case to include the newly added fields.

Fixes #81 