### PR TITLE
Bugfix for reference containing author-list = None; bugfix in references test case with REF view

### DIFF
--- a/scopus/abstract_retrieval.py
+++ b/scopus/abstract_retrieval.py
@@ -409,7 +409,7 @@ class AbstractRetrieval(Retrieval):
                 auids = None
                 affids = None
             except KeyError:  # REF view parsing
-                auth = info.get('author-list', {}).get('author', [])
+                auth = (info.get('author-list') or {}).get('author', [])
                 authors = [', '.join(filter(None, [d.get('ce:surname'),
                                                    d.get('ce:given-name')]))
                            for d in auth]

--- a/scopus/tests/test_AbstractRetrieval.py
+++ b/scopus/tests/test_AbstractRetrieval.py
@@ -326,13 +326,15 @@ def test_references():
         doi='10.1145/1721654.1721672', title='A view of cloud computing',
         sourcetitle='Communications of the ACM',
         publicationyear=None, volume='53', issue='4', first='50',
-        last='58', text=None, fulltext=None, citedbycount='4979',
+        last='58', text=None, fulltext=None, citedbycount='0',
         authors_auid='35800975300; 35571093800; 57198081560; 7202236336; '\
             '7401788602; 25926395200; 56326032000; 7401930147; 26534952300; '\
             '7007009125; 15064891400',
         authors_affiliationid='60025038; 60025038; 60025038; 60025038; 60025038; '\
             '60025038; 60025038; 60025038; 60025038; 60025038; 60025038')
-    assert_equal(ab8.references[0], expected8)
+    assert_true(int(ab8.references[0].citedbycount) >= 0)
+    assert_equal(ab8.references[0]._replace(citedbycount="0"), expected8)
+
 
 
 def test_scopus_link():


### PR DESCRIPTION
Hi, 
I noticed a bug with the updated reference method for the REF view.
If `authors-list` field is None, a `NoneType object has no attribute get` error is thrown.
Example:
```python
references = AbstractRetrieval('2-s2.0-78650926766', view="REF", refresh=True).references
```
This PR fixes this.

I also noticed that the references test was failing. This was due to a change in the `citedbycount` field in the API (probably someone cited the test paper and thus changed the value of the field). 
I updated the test case to match any integer greater than 0.