### PR TITLE
Rework search params in ScopusSearch

### DIFF
--- a/scopus/affiliation_search.py
+++ b/scopus/affiliation_search.py
@@ -49,7 +49,7 @@ class AffiliationSearch(Search):
 
         max_entries : int (optional, default=5000)
             Raise error when the number of results is beyond this number.
-            The Scopus Search Engine does not allow more than 5000 entries.
+            The Affiliation Search API does not allow more than 5000 entries.
 
         Raises
         ------

--- a/scopus/author_search.py
+++ b/scopus/author_search.py
@@ -60,7 +60,7 @@ class AuthorSearch(Search):
 
         max_entries : int (optional, default=5000)
             Raise error when the number of results is beyond this number.
-            The Scopus Search Engine does not allow more than 5000 entries.
+            The Author Search API does not allow more than 5000 entries.
 
         Raises
         ------

--- a/scopus/classes/search.py
+++ b/scopus/classes/search.py
@@ -16,7 +16,7 @@ URL = {'AffiliationSearch': BASE_URL + 'affiliation',
 
 class Search:
     def __init__(self, query, api, refresh, count=200, start=0,
-                 max_entries=5000, view='STANDARD', curosr=False, **kwds):
+                 max_entries=5000, view='STANDARD', cursor=False, **kwds):
         """Class intended as superclass to perform a search query.
 
         Parameters
@@ -95,7 +95,8 @@ class Search:
             n = int(res['search-results'].get('opensearch:totalResults', 0))
             if max_entries and n > max_entries and cursor:  # Stop if there are too many results
                 text = ('Found {} matches. Set max_entries to a higher '
-                        'number, change your query ({}) or set cursor=True'.format(n, query))
+                        'number, change your query ({}) or set
+                        'subscription=True'.format(n, query))
                 raise ScopusQueryError(text)
             self._json = res.get('search-results', {}).get('entry', [])
             if n == 0:

--- a/scopus/classes/search.py
+++ b/scopus/classes/search.py
@@ -40,7 +40,7 @@ class Search:
 
         max_entries : int (optional, default=5000)
             Raise error when the number of results is beyond this number.
-            The Scopus Search Engine does not allow more than 5000 entries.
+            To skip this check, set `max_entries` to `None`.
 
         view : str (optional, default=STANDARD)
             The view of the file that should be downloaded.  Will not take
@@ -83,7 +83,7 @@ class Search:
             params = {'query': query, 'count': count, 'start': 0, 'view': view}
             res = download(url=URL[api], params=params, accept="json", **kwds).json()
             n = int(res['search-results'].get('opensearch:totalResults', 0))
-            if n > max_entries:  # Stop if there are too many results
+            if max_entries and n > max_entries:  # Stop if there are too many results
                 text = ('Found {} matches. Set max_entries to a higher '
                         'number or change your query ({})'.format(n, query))
                 raise ScopusQueryError(text)

--- a/scopus/scopus_search.py
+++ b/scopus/scopus_search.py
@@ -139,11 +139,6 @@ class ScopusSearch(Search):
         Json results are cached in ~/.scopus/scopus_search/{fname},
         where fname is the md5-hashed version of query.
         """
-        # Checks
-        allowed_views = ('STANDARD', 'COMPLETE')
-        if view not in allowed_views:
-            raise ValueError('view parameter must be one of ' +
-                             ', '.join(allowed_views))
         # Query
         self.query = query
         if view == "COMPLETE":

--- a/scopus/scopus_search.py
+++ b/scopus/scopus_search.py
@@ -104,7 +104,7 @@ class ScopusSearch(Search):
         return out or None
 
     def __init__(self, query, refresh=False, view="COMPLETE", count=25,
-                 **kwds):
+                 max_entries=None, **kwds):
         """Class to search a query, and retrieve a list of EIDs as results.
 
         Parameters
@@ -124,6 +124,14 @@ class ScopusSearch(Search):
         count : int (optional, default=25)
             The number of entries to be displayed at once.  A smaller number
             means more queries with each query having less results.
+
+        max_entries : int (optional, default=None)
+            Raise error when the number of results is beyond this number.
+            The Scopus Search API only allows 5000 results for non-subscribers,
+            so users who don't subscribe to Scopus should set this value to
+            5000. The API doesn't have any restrictions for subscribers,
+            though, so subscribers will not want to perform this check. This
+            can be achieved by setting `max_entries` to `None`.
 
         kwds : key-value parings, optional
             Keywords passed on as query parameters.  Must contain fields
@@ -146,8 +154,9 @@ class ScopusSearch(Search):
         """
         # Query
         self.query = query
-        Search.__init__(self, query, 'ScopusSearch', refresh, max_entries=5000,
-                        count=count, start=0, view=view, **kwds)
+        Search.__init__(self, query, 'ScopusSearch', refresh,
+                        count=count, max_entries=max_entries, start=0,
+                        view=view, **kwds)
 
     def __str__(self):
         eids = self.get_eids()

--- a/scopus/scopus_search.py
+++ b/scopus/scopus_search.py
@@ -103,7 +103,8 @@ class ScopusSearch(Search):
             out.append(new)
         return out or None
 
-    def __init__(self, query, refresh=False, view="COMPLETE", **kwds):
+    def __init__(self, query, refresh=False, view="COMPLETE", count=25,
+                 **kwds):
         """Class to search a query, and retrieve a list of EIDs as results.
 
         Parameters
@@ -119,6 +120,10 @@ class ScopusSearch(Search):
             https://dev.elsevier.com/guides/ScopusSearchViews.htm.
             Allowed values: STANDARD, COMPLETE.  By default, the COMPLETE view
             is used, which returns more fields but results in a slower query.
+
+        count : int (optional, default=25)
+            The number of entries to be displayed at once.  A smaller number
+            means more queries with each query having less results.
 
         kwds : key-value parings, optional
             Keywords passed on as query parameters.  Must contain fields
@@ -141,10 +146,6 @@ class ScopusSearch(Search):
         """
         # Query
         self.query = query
-        if view == "COMPLETE":
-            count = 25
-        else:
-            count = 200
         Search.__init__(self, query, 'ScopusSearch', refresh, max_entries=5000,
                         count=count, start=0, view=view, **kwds)
 


### PR DESCRIPTION
This PR allows the user to pass `count` and `max_entries` to `ScopusSearch()`, closing #84. A few misc notes:

* I've kept the `max_entries` param and allowed the user to set it to `None` if they don't want to perform the check. 
* I chose to use `max_entries=None` as the default in `ScopusSearch()`, as that would be the value that most scopus subscribers would want to use and you mentioned that subscribers are the primary users of the package. `AuthorSearch` and `AffiliationSearch` keep their defaults of 5000 because that limit still exists for both subscribers and non-subscribers of the Author Search and Affiliation Search APIs. 
* The default value for `count` is 25 in `ScopusSearch()`, as `view` defaults to "COMPLETE" and thus `count` should conform to this default view. 