### PR TITLE
Making available the use of proxies

### DIFF
--- a/scopus/abstract_retrieval.py
+++ b/scopus/abstract_retrieval.py
@@ -555,15 +555,17 @@ class AbstractRetrieval(Retrieval):
 
         view : str (optional, default=META_ABS)
             The view of the file that should be downloaded.  Will not take
-            effect for already cached files. Allowed values: META, META_ABS,
-            REF, FULL, where FULL includes all information of META_ABS view and
-            META_ABS includes all information of the META view .  See
+            effect for already cached files.  Allowed values: META, META_ABS,
+            REF, FULL, where FULL includes all information of META_ABS view
+            and META_ABS includes all information of the META view.  See
             https://dev.elsevier.com/guides/AbstractRetrievalViews.htm
             for details.
 
         refresh : bool (optional, default=False)
             Whether to refresh the cached file if it exists or not.
 
+        Raises
+        ------
         ValueError
             If the id_type parameter or the view parameter contains
             invalid entries.

--- a/scopus/utils/get_content.py
+++ b/scopus/utils/get_content.py
@@ -97,6 +97,13 @@ def download(url, params=None, accept="xml", **kwds):
     header.update({'Accept': 'application/{}'.format(accept)})
     # Perform request
     params.update(**kwds)
+    # If config.ini has a section as follows:
+    #
+    # [Proxy]
+    # https = protocol://server:port
+    #
+    # it uses a proxy as defined
+    # see requests documentation for details
     if config.has_section("Proxy"):
         proxyDict = dict(config.items("Proxy"))
         resp = requests.get(url, headers=header, proxies=proxyDict, params=params)

--- a/scopus/utils/get_content.py
+++ b/scopus/utils/get_content.py
@@ -97,7 +97,11 @@ def download(url, params=None, accept="xml", **kwds):
     header.update({'Accept': 'application/{}'.format(accept)})
     # Perform request
     params.update(**kwds)
-    resp = requests.get(url, headers=header, params=params)
+    if config.has_section("Proxy"):
+        proxyDict = dict(config.items("Proxy"))
+        resp = requests.get(url, headers=header, proxies=proxyDict, params=params)
+    else:
+        resp = requests.get(url, headers=header, params=params)
     # Raise error if necessary
     try:
         reason = resp.reason.upper() + " for url: " + url


### PR DESCRIPTION
For tunneling network traffic via my institution's network, I use ssh. In this case (and maybe comparable solutions via vpn) I need to make available requests.get capability of using proxies.  This patch hands over a config.ini section like 

```
[Proxy]
ftp = socks5://127.0.0.1:1234
http = socks5://127.0.0.1:1234
https = socks5://127.0.0.1:1234
```

for requests.get to use accordingly. 